### PR TITLE
Fix duplicate turnFanOn export entry in lightFanService

### DIFF
--- a/lightFanService.js
+++ b/lightFanService.js
@@ -65,7 +65,7 @@ module.exports = function (got, logger, options) {
         lightAndFanOnOffPostSessionTimer: lightAndFanOnOffPostSessionTimer,
         turnLightOff: turnLightOff,
         turnFanOff: turnFanOff,
-        turnFanOn,turnFanOn,
+        turnFanOn: turnFanOn,
         turnLightOn: turnLightOn
     }
 };


### PR DESCRIPTION
## Summary
- fix lightFanService export to define turnFanOn only once

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68956966ae0883319f8a1ece3dc1f163