### PR TITLE
feat: add default color for color service

### DIFF
--- a/optionsExample.js
+++ b/optionsExample.js
@@ -1,6 +1,11 @@
 module.exports.apiKey = 'API_KEY_GOES_HERE';
 module.exports.defaultRGBColor = '255,127,0';
 module.exports.defaultSaunaRGBColor = '255,127,0';
+// Default hex/name pair used by colorService when no color is specified
+module.exports.defaultColor = {
+    hex: '#ff7f00',
+    name: 'Orange'
+};
 module.exports.webhookKey = 'WEBHOOK_KEY_GOES_HERE';
 module.exports.loggerLevel = 'debug';
 const iftttApiKey = 'IFTTT_API_KEY_GOES_HERE';


### PR DESCRIPTION
## Summary
- export defaultColor hex/name pair for colorService fallback

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689569769ed08331b92e01ee834d2b60