### PR TITLE
Add tests for colorService and configure Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "MIT",
@@ -14,5 +14,8 @@
     "express": "^4.18.1",
     "got": "^11",
     "log4js": "6.5.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/test/colorService.test.js
+++ b/test/colorService.test.js
@@ -1,0 +1,26 @@
+const createColorService = require('../colorService');
+
+describe('colorService', () => {
+  const options = { defaultColor: { hex: '#ffffff', name: 'Default' } };
+  const service = createColorService(options);
+
+  describe('hexToRgb', () => {
+    test('converts 6-digit hex to RGB', () => {
+      expect(service.hexToRgb('#ff5733')).toEqual({ r: 255, g: 87, b: 51 });
+    });
+
+    test('converts shorthand hex to RGB', () => {
+      expect(service.hexToRgb('#03f')).toEqual({ r: 0, g: 51, b: 255 });
+    });
+  });
+
+  describe('nearestColor', () => {
+    test('returns correct base color for known hex', () => {
+      expect(service.nearestColor('#ff0000')).toEqual({ hex: '#ff0000', name: 'Red' });
+    });
+
+    test('falls back to defaultColor when input is null', () => {
+      expect(service.nearestColor(null)).toEqual(options.defaultColor);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering `hexToRgb` and `nearestColor`
- configure npm test script to run Jest

## Testing
- `npm test` (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_6895698317fc8331a6f533c379dc4649