### PR TITLE
Fix color name and function export

### DIFF
--- a/colorService.js
+++ b/colorService.js
@@ -8,10 +8,10 @@ module.exports = function (options) {
 			"hex": "#000000",
 			"name": "Black",
 		},
-		{
-			"hex": "#808080",
-			"name": "White",
-		},
+                {
+                        "hex": "#808080",
+                        "name": "Gray",
+                },
 
 		{
 			"hex": "#ff0000",

--- a/lightFanService.js
+++ b/lightFanService.js
@@ -1,5 +1,3 @@
-const { urlencoded } = require("body-parser");
-
 module.exports = function (got, logger, options) {
     async function turnLightOn(deviceName, device) {
         var defaultColor = options.defaultRGBColor;
@@ -65,7 +63,7 @@ module.exports = function (got, logger, options) {
         lightAndFanOnOffPostSessionTimer: lightAndFanOnOffPostSessionTimer,
         turnLightOff: turnLightOff,
         turnFanOff: turnFanOff,
-        turnFanOn,turnFanOn,
+        turnFanOn: turnFanOn,
         turnLightOn: turnLightOn
     }
 };


### PR DESCRIPTION
## Summary
- correct mis-labeled base color name for gray
- export `turnFanOn` correctly in lightFanService and drop unused import

## Testing
- `npm test >/tmp/unit.log; tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_6895572708fc8331ab46545aa24ee399