### PR TITLE
Handle transient idle status before session end

### DIFF
--- a/cronService.js
+++ b/cronService.js
@@ -120,6 +120,22 @@ module.exports = function(options, got, logger, lightFanService, getLastWebhookU
                     }
 
                     // Process the status update
+                    const previousStatus = floatDevice.status;
+                    const timeUntilEndMs =
+                        floatDevice.sessionEndTime?.getTime() - Date.now();
+                    if (
+                        floatStatus.status === 0 &&
+                        previousStatus === 3 &&
+                        floatDevice.sessionEndTime &&
+                        timeUntilEndMs > 0 &&
+                        timeUntilEndMs <= 10 * 60 * 1000
+                    ) {
+                        const minsUntilEnd = Math.ceil(timeUntilEndMs / 60000);
+                        logger.warn(
+                            `${key}: Received idle status but session end time ${formatChicagoTime(floatDevice.sessionEndTime)} is within ${minsUntilEnd} minutes - assuming session still active`
+                        );
+                        floatStatus.status = 3;
+                    }
                     logger.debug(`${key}: Calling checkFloatStatus with status: ${floatStatus.status}`);
                     await checkService.checkFloatStatus(key, floatDevice, floatStatus, silentStatus);
                     


### PR DESCRIPTION
## Summary
- Guard against spurious `status: 0` responses from float controllers
- Ignore idle status only if session end is within 10 minutes
- Keep polling rapidly and maintain session state when end time is still in the future

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b8b163c4c8331a65f783a1cb07632