### PR TITLE
Fix session end time initialization for fan timer

### DIFF
--- a/checkService.js
+++ b/checkService.js
@@ -73,16 +73,16 @@ module.exports = function(got,logger,options,lightFanService) {
                     await lightFanService.lightAndFanOnOffPostSessionTimer(deviceName,floatDevice);
                     floatDevice.endScheduleTriggered = true;
                     floatDevice.minutesInSession = 1;
-                } else if (floatDevice.minutesInSession == 0) {
+                } else if (!floatDevice.sessionEndTime) {
                     // Record absolute session end time at the start of an active session
                     const now = Date.now();
                     // Get session delay in milliseconds (convert from seconds to ms)
                     const sessionDelayMs = Number(floatStatus.session_delay_before || 0) * 1000;
                     const sessionDurationMs = Number(floatStatus.duration) * 1000; // duration reported in seconds
-                    
+
                     // Add session delay to the end time to account for delayed start
                     floatDevice.sessionEndTime = new Date(now + sessionDurationMs + sessionDelayMs);
-                    
+
                     logger.debug(`${deviceName}: sessionEndTime set (Chicago) ${floatDevice.sessionEndTime.toLocaleString('en-US', { timeZone: 'America/Chicago' })}`);
                     if (sessionDelayMs > 0) {
                         logger.info(`${deviceName}: Accounting for session delay of ${sessionDelayMs/1000} seconds in end time calculation`);


### PR DESCRIPTION
## Summary
- initialize session end time when starting an active session even if minutesInSession isn't zero
- prevents fan-on timer from being skipped

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689c400af04483318a51f0ca454b9112