### PR TITLE
refactor: clean up services

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,17 +2,16 @@ const got = require('got');
 const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
-var options = require('./options.js');
+const options = require('./options.js');
 const colorService = require('./colorService.js')(options);
 
-app.use(bodyParser.json())
+app.use(bodyParser.json());
 
-var log4js = require('log4js');
-var logger = log4js.getLogger();
+const log4js = require('log4js');
+const logger = log4js.getLogger();
 logger.level = options.loggerLevel;
-logger.info("FloatPod automation start" + options.loggerLevel);
-logger.error("FloatPod automation error start" + options.loggerLevel);
-const lightFanService = require('./lightFanService.js')(got,logger,options);
+logger.info(`FloatPod automation start ${options.loggerLevel}`);
+const lightFanService = require('./lightFanService.js')(got, logger, options);
 
 // Track last webhook update time and last session end time
 let lastWebhookUpdate = null;
@@ -75,11 +74,9 @@ app.post('/color-'+options.webhookKey, function (req, res) {
 	const chicagoTime = new Date(lastWebhookUpdate).toLocaleString('en-US', { timeZone: 'America/Chicago' });
 	logger.debug(`Color update received at: ${chicagoTime} (Chicago)`);
 	
-	var roomColor = null;
-	var rgbColor = null;
-	logger.debug('req',req.body);
+        let roomColor;
+        let rgbColor;
     try{
-		//needs refactor 
 
 		if(req.body['room_lighting_color']){
 			roomColor = colorService.nearestColor(req.body['room_lighting_color']);
@@ -128,7 +125,6 @@ app.post('/color-'+options.webhookKey, function (req, res) {
 
 		
     } catch (ex){
-		logger.debug('req.body',req.body);
         logger.error("failed to parse room_lighting_color", ex);
     }
     res.send("OK");

--- a/checkService.js
+++ b/checkService.js
@@ -1,6 +1,6 @@
-module.exports = function(got,logger,options,lightFanService) {
-    var shouldAlertDeviceInSession = true;
-    var shouldTurnHallwayLightsOff = true;
+module.exports = function(got, logger, options, lightFanService) {
+    let shouldAlertDeviceInSession = true;
+    let shouldTurnHallwayLightsOff = true;
 
     function schedulePostSessionStart(deviceName, floatDevice, minsToPlayMusicBeforeEndSession) {
         if (floatDevice.sessionEndTimer) {
@@ -26,7 +26,6 @@ module.exports = function(got,logger,options,lightFanService) {
     }
 
     async function checkFloatStatus(deviceName,floatDevice,floatStatus, silentStatus){
-        // logger.debug(`${deviceName}: floatStatus ${JSON.stringify(floatStatus)}`);
         const deviceNewSession = floatStatus.status == 1 || floatStatus.status == 2;
         const deviceActiveSession = floatStatus.status==3;
         const idleScreen = floatStatus.status == 0;
@@ -34,7 +33,7 @@ module.exports = function(got,logger,options,lightFanService) {
         floatDevice.silentStatus = silentStatus;
 
         const minsBeforeCountInSession = -1;
-        var devicesInSession = await anyDevicesInSession(minsBeforeCountInSession);
+        let devicesInSession = await anyDevicesInSession(minsBeforeCountInSession);
         if(devicesInSession == "" && !shouldTurnHallwayLightsOff) {
             shouldTurnHallwayLightsOff = true;
             //light strip on
@@ -125,7 +124,6 @@ module.exports = function(got,logger,options,lightFanService) {
             await checkForOverNightSession(deviceName, floatDevice);
 
         } else if (idleScreen) {
-            // logger.debug(`${deviceName}: no session active screen.`);
             floatDevice.minutesInSession = 0;
             floatDevice.sessionEndTime = null; // clear stored end time when idle
             if (floatDevice.sessionEndTimer) {
@@ -157,11 +155,11 @@ module.exports = function(got,logger,options,lightFanService) {
     }
 
     async function anyDevicesInSession(minsBeforeCountInSession){
-        var devicesInSession = "";
-        var count = 0;
-        for (var key in options.floatDevices) {
+        let devicesInSession = "";
+        let count = 0;
+        for (const key in options.floatDevices) {
             if (options.floatDevices.hasOwnProperty(key)) {
-                var floatDevice = options.floatDevices[key];
+                const floatDevice = options.floatDevices[key];
                 if(floatDevice.status > 0 && floatDevice.silentStatus != 1 && floatDevice.minutesInSession > minsBeforeCountInSession){
                     count++
                     devicesInSession += `${key}|`;
@@ -175,10 +173,10 @@ module.exports = function(got,logger,options,lightFanService) {
     }
 
     function anyDevicesNotInSession(){
-        var devicesNotInSession = "";
-        for (var key in options.floatDevices) {
+        let devicesNotInSession = "";
+        for (const key in options.floatDevices) {
             if (options.floatDevices.hasOwnProperty(key)) {
-                var floatDevice = options.floatDevices[key];
+                const floatDevice = options.floatDevices[key];
                 logger.debug(`notinsession ${key}`);
                 if(floatDevice.status == 0 && floatDevice.silentStatus == 0){
                     devicesNotInSession += `${key}|`;

--- a/colorService.js
+++ b/colorService.js
@@ -1,5 +1,5 @@
 module.exports = function (options) {
-	const baseColors = [
+        const baseColors = [
 		{
 			"hex": "#FFFFFF",
 			"name": "White",
@@ -44,56 +44,51 @@ module.exports = function (options) {
 	];
 
 	// from https://stackoverflow.com/a/5624139
-	function hexToRgb(hex) {
-		var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-		hex = hex.replace(shorthandRegex, function (m, r, g, b) {
-			return r + r + g + g + b + b;
-		});
+        function hexToRgb(hex) {
+                const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+                hex = hex.replace(shorthandRegex, function (m, r, g, b) {
+                        return r + r + g + g + b + b;
+                });
 
-		var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-		return result ? {
-			r: parseInt(result[1], 16),
-			g: parseInt(result[2], 16),
-			b: parseInt(result[3], 16)
-		} : null;
-	}
+                const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+                return result ? {
+                        r: parseInt(result[1], 16),
+                        g: parseInt(result[2], 16),
+                        b: parseInt(result[3], 16)
+                } : null;
+        }
 
 	// Distance between 2 colors (in RGB)
 	// https://stackoverflow.com/questions/23990802/find-nearest-color-from-a-colors-list
-	function distance(a, b) {
-		return Math.sqrt(Math.pow(a.r - b.r, 2) + Math.pow(a.g - b.g, 2) + Math.pow(a.b - b.b, 2));
-	}
+        function distance(a, b) {
+                return Math.sqrt(Math.pow(a.r - b.r, 2) + Math.pow(a.g - b.g, 2) + Math.pow(a.b - b.b, 2));
+        }
 
 	// return nearest color from array
 	function nearestColor(colorHex) {
-		var lowest = Number.POSITIVE_INFINITY;
-		var tmp;
-		let index = 0;
+                let lowest = Number.POSITIVE_INFINITY;
+                let tmp;
+                let index = 0;
+                let colorObj = null;
 
-		var colorObj = null;
+                if (colorHex != null) {
+                        baseColors.forEach((el, i) => {
+                                tmp = distance(hexToRgb(colorHex), hexToRgb(el.hex))
+                                if (tmp < lowest) {
+                                        lowest = tmp;
+                                        index = i;
+                                };
 
-		if (colorHex != null) {
-			baseColors.forEach((el, i) => {
-				tmp = distance(hexToRgb(colorHex), hexToRgb(el.hex))
-				if (tmp < lowest) {
-					lowest = tmp;
-					index = i;
-				};
+                        })
+                        colorObj = baseColors[index]
+                } else {
+                        colorObj = options.defaultColor;
+                }
 
-			})
-			colorObj = baseColors[index]
-		} else {
-			colorObj = options.defaultColor;
-		}
-
-		return colorObj;
-	}
-
-
-
-
-	return {
-		hexToRgb: hexToRgb,
-		nearestColor: nearestColor
-	}
+                return colorObj;
+        }
+        return {
+                hexToRgb: hexToRgb,
+                nearestColor: nearestColor
+        }
 };

--- a/cronService.js
+++ b/cronService.js
@@ -1,6 +1,7 @@
 module.exports = function(options, got, logger, lightFanService, getLastWebhookUpdate, getLastSessionEndTime, setLastSessionEndTime) {
     const checkService = require('./checkService.js')(got,logger,options,lightFanService);
     const cron = require('cron').CronJob;
+    const { formatChicagoTime: formatChicagoTimeBase } = require('./timeUtils.js');
     
     // Track the last time any session ended (for rolling 1-hour fast polling window)
     let lastSessionEndTime = 0;
@@ -12,9 +13,9 @@ module.exports = function(options, got, logger, lightFanService, getLastWebhookU
     const outOfSessionChecks = {};
 
     const deviceLocks = {};
-    
+
     function formatChicagoTime(date) {
-        return date.toLocaleString('en-US', { timeZone: 'America/Chicago', hour12: false });
+        return formatChicagoTimeBase(date, { hour12: false });
     }
     
     function isNightTime() {
@@ -105,7 +106,7 @@ module.exports = function(options, got, logger, lightFanService, getLastWebhookU
                         if (!isNaN(sessionEndTimestamp) && sessionEndTimestamp > 0) {
                             // Update the rolling window for fast polling
                             lastSessionEndTime = Date.now();
-                            logger.debug(`${key}: Session ended, fast polling active until ${new Date(lastSessionEndTime + (60 * 60 * 1000)).toLocaleString()}`);
+                            logger.debug(`${key}: Session ended, fast polling active until ${formatChicagoTime(new Date(lastSessionEndTime + (60 * 60 * 1000)))} (Chicago)`);
                             
                             // Also update the session end time for other components
                             setLastSessionEndTime(sessionEndTimestamp);

--- a/lightFanService.js
+++ b/lightFanService.js
@@ -1,11 +1,11 @@
 module.exports = function (got, logger, options) {
     async function turnLightOn(deviceName, device) {
-        var defaultColor = options.defaultRGBColor;
+        let defaultColor = options.defaultRGBColor;
         if (deviceName == 'Infrared Sauna'){
             defaultColor = options.defaultSaunaRGBColor;
         }
 
-        var rgbColor = device.lightStripRGBColor ? device.lightStripRGBColor : defaultColor;
+        let rgbColor = device.lightStripRGBColor ? device.lightStripRGBColor : defaultColor;
         if(rgbColor != '0,0,0'){
             logger.info(`turning ${deviceName} light on and to color ${rgbColor}`)
             const lightColorUrl = generateIftttURL(device, options.ifttt.event.lightColorRGB);
@@ -62,7 +62,7 @@ module.exports = function (got, logger, options) {
     }
 
     function generateIftttURL(floatDevice, event) {
-        var url = options.ifttt.preUrl + floatDevice.iftttDeviceName + event + options.ifttt.postUrl;
+        const url = options.ifttt.preUrl + floatDevice.iftttDeviceName + event + options.ifttt.postUrl;
         return url;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "^1.20.0",
         "cron": "2.0.0",
         "express": "^4.18.1",
         "got": "^11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.20.0",
     "cron": "2.0.0",
     "express": "^4.18.1",
     "got": "^11",

--- a/timeUtils.js
+++ b/timeUtils.js
@@ -1,0 +1,6 @@
+function formatChicagoTime(dateOrMs, options = {}) {
+  const date = dateOrMs instanceof Date ? dateOrMs : new Date(dateOrMs);
+  return date.toLocaleString('en-US', { timeZone: 'America/Chicago', ...options });
+}
+
+module.exports = { formatChicagoTime };


### PR DESCRIPTION
## Summary
- streamline startup logging and remove unused error message
- modernize service modules using const/let and drop stale debugging
- tidy color handling helpers

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6a7e66488331b5bf51578e02996b